### PR TITLE
Update container ID regex

### DIFF
--- a/context.go
+++ b/context.go
@@ -185,7 +185,7 @@ func GetCurrentContainerID() string {
 }
 
 func matchDockerCurrentContainerID(lines string) string {
-	regex := "/var/lib/docker/containers[/-]([[:alnum:]]{64})/"
+	regex := "/lib/docker/containers[/-]([[:alnum:]]{64})/"
 	re := regexp.MustCompilePOSIX(regex)
 
 	if re.MatchString(lines) {


### PR DESCRIPTION
In some cases, the container path in `/proc/self/mountinfo` does not start with the `var` folder. In my case it is `/lib/docker/containers/<ContainerID>`. This leads to the error that no container IDs can be found. Therefore I have adapted the regex.